### PR TITLE
Add multi-arch CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           cross build --release --target ${{ matrix.target }} --manifest-path Rust/${{ matrix.crate }}/Cargo.toml
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.crate }}-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/engarde_server

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build Rust binaries
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "armv7-unknown-linux-gnueabihf"]
+        crate: ["Server", "Client"]
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross --locked
+
+      - name: Build
+        run: |
+          cross build --release --target ${{ matrix.target }} --manifest-path Rust/${{ matrix.crate }}/Cargo.toml
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.crate }}-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/engarde_server
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds both Rust crates for x86_64, armv7 and aarch64

## Testing
- `cargo check --quiet --manifest-path Rust/Server/Cargo.toml`
- `cargo check --quiet --manifest-path Rust/Client/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6884b1e587dc8327918a4410455763e9