### PR TITLE
Fix typos in Makefile and add build call

### DIFF
--- a/Owrt app Source/luci-app-engarde-easyconf/Makefile
+++ b/Owrt app Source/luci-app-engarde-easyconf/Makefile
@@ -2,13 +2,13 @@
 
 include $(TOPDIR)/rules.mk
 PKG_NAME:=luci-app-engarde-easyconf
-LUCI_Title:=Engarde cloud-init automated configuration with Wireguard autoconf
+LUCI_TITLE:=Engarde cloud-init automated configuration with Wireguard autoconf
 LUCI_PKGARCH:=all
 LUCI_DEPENDS:=+libuci
 PKG_VERSION:=1.0
 PKG_RELEASE:=1.0
 
-PKG_MAINTANINER:=TALMASH
+PKG_MAINTAINER:=TALMASH
 PKG_LICENSE:=BSD
 PKG_LICENSE_FILES:=LICENSE
 
@@ -16,3 +16,4 @@ PKG_LICENSE_FILES:=LICENSE
 include $(TOPDIR)/feeds/luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature
+$(call BuildPackage,$(PKG_NAME))


### PR DESCRIPTION
## Summary
- fix LUCI title variable spelling
- fix maintainer variable name
- call `BuildPackage` explicitly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cc12574b883279ae06451286b311d