### PR TITLE
Fix file viewer path

### DIFF
--- a/Owrt app Source/luci-app-engarde-easyconf/luasrc/controller/engardeconf/engardeconf.lua
+++ b/Owrt app Source/luci-app-engarde-easyconf/luasrc/controller/engardeconf/engardeconf.lua
@@ -24,6 +24,6 @@ end
 
 function engardelog()
     local logfile = fs.readfile("/tmp/engarde.log") or ""
-    template.render("tinyvpnconf/file_viewer",
+    template.render("engardeconf/file_viewer",
         {title = i18n.translate("Service Script Log"), content = logfile})
 end


### PR DESCRIPTION
## Summary
- update path for Engarde log viewer template

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688cc1c936848327b38f93bb46e04a50