### PR TITLE
Add Engarde OpenWrt service

### DIFF
--- a/Owrt app Source/luci-app-engarde-easyconf/root/etc/config/engardeconf
+++ b/Owrt app Source/luci-app-engarde-easyconf/root/etc/config/engardeconf
@@ -1,0 +1,4 @@
+config config 'Setup'
+    option enabled '0'
+    option pass ''
+    option dstAddr ''

--- a/Owrt app Source/luci-app-engarde-easyconf/root/etc/init.d/engardeconf
+++ b/Owrt app Source/luci-app-engarde-easyconf/root/etc/init.d/engardeconf
@@ -1,0 +1,43 @@
+#!/bin/sh /etc/rc.common
+# Engarde client init script
+
+START=95
+USE_PROCD=1
+PROG=/usr/bin/engarde-client
+CFGFILE=/etc/engarde.yml
+LOGFILE=/tmp/engarde.log
+
+start_service() {
+    echo "Starting engarde" >$LOGFILE
+    config_load engardeconf
+    config_get_bool enabled Setup enabled 0
+    [ "$enabled" = "1" ] || { echo "Engarde disabled" >>$LOGFILE; return 1; }
+    config_get pass Setup pass
+    config_get dstAddr Setup dstAddr
+    mkdir -p /etc
+    cat >$CFGFILE <<EOC
+client:
+  description: "openwrt-client"
+  listenAddr: "127.0.0.1:59401"
+  dstAddr: "${dstAddr}:65531"
+  writeTimeout: 10
+  excludedInterfaces:
+    - "wg0"
+    - "lo"
+  dstOverrides: []
+  webManager:
+    listenAddr: "0.0.0.0:9001"
+    username: "engarde"
+    password: "${pass}"
+EOC
+    procd_open_instance
+    procd_set_param command $PROG $CFGFILE
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_set_param respawn
+    procd_close_instance
+}
+
+stop_service() {
+    echo "Stopping engarde" >>$LOGFILE
+}

--- a/Owrt app Source/luci-app-engarde-easyconf/root/etc/uci-defaults/50-luci-engardeconf
+++ b/Owrt app Source/luci-app-engarde-easyconf/root/etc/uci-defaults/50-luci-engardeconf
@@ -1,10 +1,16 @@
 #!/bin/sh
 
 uci -q batch <<-EOF >/dev/null
-	delete ucitrack.@engardeconf[-1]
-	add ucitrack engardeconf
+    delete ucitrack.@engardeconf[-1]
+    add ucitrack engardeconf
     set ucitrack.@engardeconf[-1].init=engardeconf
-	commit ucitrack
+    commit ucitrack
+    delete engardeconf.Setup
+    set engardeconf.Setup=config
+    set engardeconf.Setup.enabled='0'
+    set engardeconf.Setup.pass=''
+    set engardeconf.Setup.dstAddr=''
+    commit engardeconf
 EOF
 
 exit 0


### PR DESCRIPTION
## Summary
- provide init script for Engarde client
- include default UCI config
- ensure defaults installed in uci-defaults script

## Testing
- `shellcheck Owrt\ app\ Source/luci-app-engarde-easyconf/root/etc/init.d/engardeconf`
- `cargo check` in `Rust/Client` and `Rust/Server`


------
https://chatgpt.com/codex/tasks/task_e_688cc39eba588327bf8ec3b5bd37db87