### PR TITLE
Add username and server options

### DIFF
--- a/Owrt app Source/luci-app-engarde-easyconf/luasrc/model/cbi/engardeconf/engardeconf.lua
+++ b/Owrt app Source/luci-app-engarde-easyconf/luasrc/model/cbi/engardeconf/engardeconf.lua
@@ -2,8 +2,14 @@ config = Map("engardeconf")
 
 view = config:section(NamedSection,"Setup", "config",  translate("Engarde Configuration (cloud-init)"))
 enabled = view:option(Flag, "enabled", "Enable", "Enables Engarde and Wireguard, disabling Speedify and TinyFEC VPN.<br>Wait 20-30 seconds for Engarde & UI change to commence."); view.optional=false; view.rmempty = false;
-pass = view:option(Value, "pass", "Password:", "The password set in cloud-init password field."); pass.optional=false; pass.rmempty = false; pass.password=true;
-server = view:option(Value, "dstAddr", "Server IP Address:", "The server IP(v4), found in provider instance info.");
+pass = view:option(Value, "pass", "Password:", "Password for Engarde Web Manager.");
+pass.optional=false; pass.rmempty = false; pass.password=true;
+server = view:option(Value, "dstAddr", "Server Address:",
+    "IP address or hostname of the Engarde server.");
+server.optional=false; server.rmempty = false;
+user = view:option(Value, "username", "Username:",
+    "Username for Engarde Web Manager.");
+user.optional=false; user.rmempty = false;
 
 function config.on_commit(self)
     luci.sys.exec("sh -c 'sleep 2 && /etc/init.d/engardeconf restart' &")

--- a/Owrt app Source/luci-app-engarde-easyconf/luasrc/view/engardeconf/guidehelp.htm
+++ b/Owrt app Source/luci-app-engarde-easyconf/luasrc/view/engardeconf/guidehelp.htm
@@ -26,7 +26,7 @@
 <h5>You can wait few minutes or monitor progress by clicking View Console</h5>
 <img style="border:6px solid #d2ccf1;" src="/luci-static/resources/view/engardeconf/7.webp" style="max-height:300px"/><br>
 <img style="border:6px solid #d2ccf1;" src="/luci-static/resources/view/engardeconf/8.webp" style="max-height:300px"/><br>
-<h5>Copy the noted IP address & password in the configuration tab of this page and check Enable, Save & Apply</h5>
+<h5>Copy the noted IP address, username and password in the configuration tab of this page and check Enable, Save & Apply</h5>
 <img style="border:6px solid #d2ccf1;" src="/luci-static/resources/view/engardeconf/9.webp" style="max-height:300px"/><br>
 <h5>Engarde will automatically detect connectivty via any interface in Active Interfaces section and use it!</h5>
 <img style="border:6px solid #d2ccf1;" src="/luci-static/resources/view/engardeconf/10.webp" style="max-height:300px"/><br>

--- a/Owrt app Source/luci-app-engarde-easyconf/root/etc/config/engardeconf
+++ b/Owrt app Source/luci-app-engarde-easyconf/root/etc/config/engardeconf
@@ -1,4 +1,5 @@
 config config 'Setup'
     option enabled '0'
     option pass ''
+    option username 'engarde'
     option dstAddr ''

--- a/Owrt app Source/luci-app-engarde-easyconf/root/etc/init.d/engardeconf
+++ b/Owrt app Source/luci-app-engarde-easyconf/root/etc/init.d/engardeconf
@@ -13,6 +13,7 @@ start_service() {
     config_get_bool enabled Setup enabled 0
     [ "$enabled" = "1" ] || { echo "Engarde disabled" >>$LOGFILE; return 1; }
     config_get pass Setup pass
+    config_get username Setup username
     config_get dstAddr Setup dstAddr
     mkdir -p /etc
     cat >$CFGFILE <<EOC
@@ -27,7 +28,7 @@ client:
   dstOverrides: []
   webManager:
     listenAddr: "0.0.0.0:9001"
-    username: "engarde"
+    username: "${username}"
     password: "${pass}"
 EOC
     procd_open_instance

--- a/Owrt app Source/luci-app-engarde-easyconf/root/etc/uci-defaults/50-luci-engardeconf
+++ b/Owrt app Source/luci-app-engarde-easyconf/root/etc/uci-defaults/50-luci-engardeconf
@@ -9,6 +9,7 @@ uci -q batch <<-EOF >/dev/null
     set engardeconf.Setup=config
     set engardeconf.Setup.enabled='0'
     set engardeconf.Setup.pass=''
+    set engardeconf.Setup.username='engarde'
     set engardeconf.Setup.dstAddr=''
     commit engardeconf
 EOF


### PR DESCRIPTION
## Summary
- expose server address, username, and password fields in the Engarde LuCI form
- persist these new options in `/etc/config/engardeconf`
- use them when building `/etc/engarde.yml`
- update the setup guide text

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688cc6ccf5608327876aed34fcfd1d12