### PR TITLE
Add weighted round robin aggregation support

### DIFF
--- a/Docs/Setup.md
+++ b/Docs/Setup.md
@@ -159,7 +159,18 @@ echo "net.core.wmem_default=33554432" >> /etc/sysctl.conf
 echo "net.core.rmem_max=33554432" >> /etc/sysctl.conf
 echo "net.core.rmem_default=33554432" >> /etc/sysctl.conf
 ```
-You might also try changing the txqueuelen for the wireguard interface and/or on the wan interfaces 
+
+### Nuovi algoritmi di aggregazione
+
+Nel file `/etc/engarde.yml` (o in quello che preferisci utilizzare) è stata aggiunta la chiave `aggregationAlgorithm` per decidere come distribuire i pacchetti sulle WAN disponibili:
+
+* `1` – comportamento storico: ogni pacchetto viene replicato su tutte le connessioni.
+* `2` – aggregazione pura con **weighted round robin**. Il peso predefinito è `1.0` per ogni interfaccia; il file dei pesi viene creato automaticamente accanto alla configurazione (`engarde.weights.yml`). Puoi modificarlo manualmente (formato YAML `nome_interfaccia: peso`) per preferire un link rispetto ad un altro.
+* `3` – modalità ibrida (WIP al momento, verrà documentata in futuro).
+
+> Suggerimento: se vuoi spostare il file dei pesi in un percorso personalizzato puoi usare l'opzione `weightsFile` nel blocco `client`.
+
+You might also try changing the txqueuelen for the wireguard interface and/or on the wan interfaces
 
 ```bash
 ip link set wg0 txqueuelen 10000

--- a/README.md
+++ b/README.md
@@ -21,9 +21,26 @@ Absolutely yes. The used bandwidth is the one you would normally use multiplied 
 ## For the rust version they are available on the release page!
 Or if you want to compile them you can just download the project and build it , the angular project for the webui is the same as the one used on the go version because i have no idea on how to modify so i am providing a compiled version of the static binaries , for the code to build it yourself check (https://github.com/porech/engarde).
 
-## How do i use it? 
+## How do i use it?
 
 ### [SETUP GUIDE WIP](Docs/Setup.md)
+
+## Aggregation algorithms
+
+Engarde now supports multiple aggregation strategies that can be selected from the client configuration (`aggregationAlgorithm`).
+
+1. **Mirror all (default)** – each packet coming from WireGuard is sent through every available WAN, exactly like the historical behaviour. This maximises resiliency at the cost of bandwidth.
+2. **Pure aggregation (weighted round robin)** – packets are distributed across the active WANs according to the weights defined in the weight file. Each interface starts with weight `1.0` and the file can be edited manually to bias the traffic towards specific links.
+3. **Hybrid mode** – WIP. The documentation (and implementation) will be completed in a future iteration.
+
+The weight file defaults to `<config-name>.weights.yml` in the same directory as `engarde.yml` (for example `/etc/engarde.weights.yml`). The format is a simple YAML mapping:
+
+```yaml
+eth0: 2.5
+wwan0: 1.0
+```
+
+Whenever a new interface is detected, Engarde automatically ensures it exists inside the weight file with the default `1.0` value.
 
 ## How can I check if everything is working?
 There is an Angular web interface embedded in both the client and the server. Please have a look to the comments in the [example config file](https://github.com/porech/engarde/blob/master/engarde.yml.sample) for more information about how to enable it.

--- a/client-wizard.sh
+++ b/client-wizard.sh
@@ -110,6 +110,7 @@ client:
   listenAddr: "$ENG_LISTEN"
   dstAddr: "$ENG_DST"
   writeTimeout: 10
+  aggregationAlgorithm: 1
   excludedInterfaces:
     - "wg0"
     - "lo"


### PR DESCRIPTION
## Summary
- add client configuration support for selecting the aggregation algorithm and implement a weighted round robin mode with automatic weight file management
- log and default newly detected interfaces to weight 1.0 while keeping a placeholder hybrid mode that falls back to mirroring
- document the new options and update the client wizard template to expose the aggregation setting

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68dbd47c2de4832789695363e4d48769