### PR TITLE
Bump Rust crate versions to 0.1.3

### DIFF
--- a/Rust/Client/Cargo.toml
+++ b/Rust/Client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engarde_server"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [dependencies]

--- a/Rust/Server/Cargo.toml
+++ b/Rust/Server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engarde_server"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
### Motivation
- Bump Rust crate versions from `0.1.2` to `0.1.3` to prepare a patch release.
- Ensure consistent versioning between the client and server crates in the repository.
- Keep package metadata up to date for downstream packaging and releases.

### Description
- Updated the `version` field in `Rust/Client/Cargo.toml` from `0.1.2` to `0.1.3`.
- Updated the `version` field in `Rust/Server/Cargo.toml` from `0.1.2` to `0.1.3`.
- No source code or dependency changes were made; this is a metadata-only change.

### Testing
- No automated tests were executed for this change because it is a version bump only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695932d36bc883278e5e124116f622c5)